### PR TITLE
Add checking stage after workers are done

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: dockerfile
 dockerfile:
-	docker build -t canyan/canyan-tester:latest .
+	docker build -t canyan/canyan-tester:master .
 
 .PHONY: venv
 venv:

--- a/canyantester/api.py
+++ b/canyantester/api.py
@@ -15,9 +15,11 @@ def api_client(apiurl: str, config: dict, stored_responses: dict):
     uri = config.get('uri', '/')
     method = config.get('method', 'POST')
     payload = config.get('payload', None)
+    expected_result = config.get('expected_result', None)
     stored_responses['random'] = {'uuid4': uuid4()}
     ipaddr = socket.gethostbyname(socket.gethostname())
     stored_responses['ipaddr'] = {'ip': ipaddr}
+
 
     variable_match = RE_VARIABLE(uri)
     if variable_match is not None:
@@ -42,7 +44,15 @@ def api_client(apiurl: str, config: dict, stored_responses: dict):
         if response.status_code != 200:
             sys.exit(1)
         data = json.loads(response.text)
-        if isinstance(data, dict):
+        if expected_result:
+            print('Comparing results...')
+            if data != json.loads(expected_result):
+                print('NO Match! exiting...')
+                sys.exit(1)
+            else:
+                print('OK')
+                return data
+        elif isinstance(data, dict):
             return data
         else:
             return None


### PR DESCRIPTION
Used to check via API the correct insertion of data after the workers finish to run.
Useful in cases where we want to check that the system has recorded a transaction.